### PR TITLE
Cross account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can download release builds through the [releases section of this](https://g
   <dependency>
     <groupId>software.amazon.payloadoffloading</groupId>
     <artifactId>payloadoffloading-common</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <type>jar</type>
   </dependency>
 ```                                                                                                                     

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.payloadoffloading</groupId>
     <artifactId>payloadoffloading-common</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
     <name>Payload offloading common library for AWS</name>
     <description>Common library between extended Amazon AWS clients to save payloads up to 2GB on Amazon S3.</description>

--- a/src/main/java/software/amazon/payloadoffloading/PayloadStorageConfiguration.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStorageConfiguration.java
@@ -3,6 +3,7 @@ package software.amazon.payloadoffloading;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -21,6 +22,10 @@ public class PayloadStorageConfiguration {
     private boolean alwaysThroughS3 = false;
     private boolean payloadSupport = false;
     /**
+     * This field is optional, it is set only when we want to add access control list to Amazon S3 buckets and objects
+     */
+    private CannedAccessControlList cannedAccessControlList;
+    /**
      * This field is optional, it is set only when we want to configure S3 Server Side Encryption with KMS.
      */
     private SSEAwsKeyManagementParams sseAwsKeyManagementParams;
@@ -29,6 +34,7 @@ public class PayloadStorageConfiguration {
         s3 = null;
         s3BucketName = null;
         sseAwsKeyManagementParams = null;
+        cannedAccessControlList = null;
     }
 
     public PayloadStorageConfiguration(PayloadStorageConfiguration other) {
@@ -38,6 +44,7 @@ public class PayloadStorageConfiguration {
         this.payloadSupport = other.isPayloadSupportEnabled();
         this.alwaysThroughS3 = other.isAlwaysThroughS3();
         this.payloadSizeThreshold = other.getPayloadSizeThreshold();
+        this.cannedAccessControlList = other.cannedAccessControlList;
     }
 
     /**
@@ -211,5 +218,40 @@ public class PayloadStorageConfiguration {
      */
     public void setAlwaysThroughS3(boolean alwaysThroughS3) {
         this.alwaysThroughS3 = alwaysThroughS3;
+    }
+
+    /**
+     * Configures the ACL to apply to the Amazon S3 putObject request.
+     * @param cannedAccessControlList
+     *            The ACL to be used when storing objects in Amazon S3
+     */
+    public void setCannedAccessControlList(CannedAccessControlList cannedAccessControlList) {
+        this.cannedAccessControlList = cannedAccessControlList;
+    }
+
+    /**
+     * Configures the ACL to apply to the Amazon S3 putObject request.
+     * @param cannedAccessControlList
+     *            The ACL to be used when storing objects in Amazon S3
+     */
+    public PayloadStorageConfiguration withCannedAccessControlList(CannedAccessControlList cannedAccessControlList) {
+        setCannedAccessControlList(cannedAccessControlList);
+        return this;
+    }
+
+    /**
+     * Checks whether an ACL have been configured for storing objects in Amazon S3.
+     * @return True if ACL is defined
+     */
+    public boolean isCannedAccessControlListDefined() {
+        return null != cannedAccessControlList;
+    }
+
+    /**
+     * Gets the AWS ACL to apply to the Amazon S3 putObject request.
+     * @return Amazon S3 object ACL
+     */
+    public CannedAccessControlList getCannedAccessControlList() {
+        return cannedAccessControlList;
     }
 }

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -1,5 +1,6 @@
 package software.amazon.payloadoffloading;
 
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -15,6 +16,7 @@ public class S3BackedPayloadStore implements PayloadStore {
     private final String s3BucketName;
     private final S3Dao s3Dao;
     private final SSEAwsKeyManagementParams sseAwsKeyManagementParams;
+    private final CannedAccessControlList cannedAccessControlList;
 
     public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName) {
         this(s3Dao, s3BucketName, null);
@@ -22,9 +24,15 @@ public class S3BackedPayloadStore implements PayloadStore {
 
     public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName,
                                 SSEAwsKeyManagementParams sseAwsKeyManagementParams) {
+        this(s3Dao, s3BucketName, sseAwsKeyManagementParams, null);
+    }
+
+    public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName,
+                                SSEAwsKeyManagementParams sseAwsKeyManagementParams, CannedAccessControlList cannedAccessControlList) {
         this.s3BucketName = s3BucketName;
         this.s3Dao = s3Dao;
         this.sseAwsKeyManagementParams = sseAwsKeyManagementParams;
+        this.cannedAccessControlList = cannedAccessControlList;
     }
 
     @Override
@@ -32,7 +40,7 @@ public class S3BackedPayloadStore implements PayloadStore {
         String s3Key = UUID.randomUUID().toString();
 
         // Store the payload content in S3.
-        s3Dao.storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, payload, payloadContentSize);
+        s3Dao.storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, cannedAccessControlList, payload, payloadContentSize);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
 
         // Convert S3 pointer (bucket name, key, etc) to JSON string

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -15,24 +15,10 @@ public class S3BackedPayloadStore implements PayloadStore {
 
     private final String s3BucketName;
     private final S3Dao s3Dao;
-    private final SSEAwsKeyManagementParams sseAwsKeyManagementParams;
-    private final CannedAccessControlList cannedAccessControlList;
 
     public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName) {
-        this(s3Dao, s3BucketName, null);
-    }
-
-    public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName,
-                                SSEAwsKeyManagementParams sseAwsKeyManagementParams) {
-        this(s3Dao, s3BucketName, sseAwsKeyManagementParams, null);
-    }
-
-    public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName,
-                                SSEAwsKeyManagementParams sseAwsKeyManagementParams, CannedAccessControlList cannedAccessControlList) {
         this.s3BucketName = s3BucketName;
         this.s3Dao = s3Dao;
-        this.sseAwsKeyManagementParams = sseAwsKeyManagementParams;
-        this.cannedAccessControlList = cannedAccessControlList;
     }
 
     @Override
@@ -40,7 +26,7 @@ public class S3BackedPayloadStore implements PayloadStore {
         String s3Key = UUID.randomUUID().toString();
 
         // Store the payload content in S3.
-        s3Dao.storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, cannedAccessControlList, payload, payloadContentSize);
+        s3Dao.storeTextInS3(s3BucketName, s3Key, payload, payloadContentSize);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
 
         // Convert S3 pointer (bucket name, key, etc) to JSON string

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -1,7 +1,5 @@
 package software.amazon.payloadoffloading;
 
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/software/amazon/payloadoffloading/S3Dao.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3Dao.java
@@ -61,12 +61,16 @@ public class S3Dao {
     }
 
     public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
-                              String payloadContentStr, Long payloadContentSize) {
+                              CannedAccessControlList cannedAccessControlList, String payloadContentStr, Long payloadContentSize) {
         InputStream payloadContentStream = new ByteArrayInputStream(payloadContentStr.getBytes(StandardCharsets.UTF_8));
         ObjectMetadata payloadContentStreamMetadata = new ObjectMetadata();
         payloadContentStreamMetadata.setContentLength(payloadContentSize);
         PutObjectRequest putObjectRequest = new PutObjectRequest(s3BucketName, s3Key,
                 payloadContentStream, payloadContentStreamMetadata);
+
+        if (cannedAccessControlList != null) {
+            putObjectRequest.withCannedAcl(cannedAccessControlList);
+        }
 
         // https://docs.aws.amazon.com/AmazonS3/latest/dev/kms-using-sdks.html
         if (sseAwsKeyManagementParams != null) {
@@ -87,6 +91,11 @@ public class S3Dao {
             LOG.error(errorMessage, e);
             throw new AmazonClientException(errorMessage, e);
         }
+    }
+
+    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
+                              String payloadContentStr, Long payloadContentSize) {
+        storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, null, payloadContentStr, payloadContentSize);
     }
 
     public void storeTextInS3(String s3BucketName, String s3Key, String payloadContentStr, Long payloadContentSize) {

--- a/src/main/java/software/amazon/payloadoffloading/S3Dao.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3Dao.java
@@ -68,44 +68,6 @@ public class S3Dao {
         return embeddedText;
     }
 
-//    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
-//                              CannedAccessControlList cannedAccessControlList, String payloadContentStr, Long payloadContentSize) {
-//        InputStream payloadContentStream = new ByteArrayInputStream(payloadContentStr.getBytes(StandardCharsets.UTF_8));
-//        ObjectMetadata payloadContentStreamMetadata = new ObjectMetadata();
-//        payloadContentStreamMetadata.setContentLength(payloadContentSize);
-//        PutObjectRequest putObjectRequest = new PutObjectRequest(s3BucketName, s3Key,
-//                payloadContentStream, payloadContentStreamMetadata);
-//
-//        if (cannedAccessControlList != null) {
-//            putObjectRequest.withCannedAcl(cannedAccessControlList);
-//        }
-//
-//        // https://docs.aws.amazon.com/AmazonS3/latest/dev/kms-using-sdks.html
-//        if (sseAwsKeyManagementParams != null) {
-//            LOG.debug("Using SSE-KMS in put object request.");
-//            putObjectRequest.setSSEAwsKeyManagementParams(sseAwsKeyManagementParams);
-//        }
-//
-//        try {
-//            s3Client.putObject(putObjectRequest);
-//
-//        } catch (AmazonServiceException e) {
-//            String errorMessage = "Failed to store the message content in an S3 object.";
-//            LOG.error(errorMessage, e);
-//            throw new AmazonServiceException(errorMessage, e);
-//
-//        } catch (AmazonClientException e) {
-//            String errorMessage = "Failed to store the message content in an S3 object.";
-//            LOG.error(errorMessage, e);
-//            throw new AmazonClientException(errorMessage, e);
-//        }
-//    }
-//
-//    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
-//                              String payloadContentStr, Long payloadContentSize) {
-//        storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, null, payloadContentStr, payloadContentSize);
-//    }
-
     public void storeTextInS3(String s3BucketName, String s3Key, String payloadContentStr, Long payloadContentSize) {
         InputStream payloadContentStream = new ByteArrayInputStream(payloadContentStr.getBytes(StandardCharsets.UTF_8));
         ObjectMetadata payloadContentStreamMetadata = new ObjectMetadata();

--- a/src/main/java/software/amazon/payloadoffloading/S3Dao.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3Dao.java
@@ -19,9 +19,17 @@ import java.nio.charset.StandardCharsets;
 public class S3Dao {
     private static final Log LOG = LogFactory.getLog(S3Dao.class);
     private final AmazonS3 s3Client;
+    private final SSEAwsKeyManagementParams sseAwsKeyManagementParams;
+    private final CannedAccessControlList cannedAccessControlList;
 
     public S3Dao(AmazonS3 s3Client) {
+        this(s3Client, null, null);
+    }
+
+    public S3Dao(AmazonS3 s3Client, SSEAwsKeyManagementParams sseAwsKeyManagementParams, CannedAccessControlList cannedAccessControlList) {
         this.s3Client = s3Client;
+        this.sseAwsKeyManagementParams = sseAwsKeyManagementParams;
+        this.cannedAccessControlList = cannedAccessControlList;
     }
 
     public String getTextFromS3(String s3BucketName, String s3Key) {
@@ -60,8 +68,45 @@ public class S3Dao {
         return embeddedText;
     }
 
-    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
-                              CannedAccessControlList cannedAccessControlList, String payloadContentStr, Long payloadContentSize) {
+//    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
+//                              CannedAccessControlList cannedAccessControlList, String payloadContentStr, Long payloadContentSize) {
+//        InputStream payloadContentStream = new ByteArrayInputStream(payloadContentStr.getBytes(StandardCharsets.UTF_8));
+//        ObjectMetadata payloadContentStreamMetadata = new ObjectMetadata();
+//        payloadContentStreamMetadata.setContentLength(payloadContentSize);
+//        PutObjectRequest putObjectRequest = new PutObjectRequest(s3BucketName, s3Key,
+//                payloadContentStream, payloadContentStreamMetadata);
+//
+//        if (cannedAccessControlList != null) {
+//            putObjectRequest.withCannedAcl(cannedAccessControlList);
+//        }
+//
+//        // https://docs.aws.amazon.com/AmazonS3/latest/dev/kms-using-sdks.html
+//        if (sseAwsKeyManagementParams != null) {
+//            LOG.debug("Using SSE-KMS in put object request.");
+//            putObjectRequest.setSSEAwsKeyManagementParams(sseAwsKeyManagementParams);
+//        }
+//
+//        try {
+//            s3Client.putObject(putObjectRequest);
+//
+//        } catch (AmazonServiceException e) {
+//            String errorMessage = "Failed to store the message content in an S3 object.";
+//            LOG.error(errorMessage, e);
+//            throw new AmazonServiceException(errorMessage, e);
+//
+//        } catch (AmazonClientException e) {
+//            String errorMessage = "Failed to store the message content in an S3 object.";
+//            LOG.error(errorMessage, e);
+//            throw new AmazonClientException(errorMessage, e);
+//        }
+//    }
+//
+//    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
+//                              String payloadContentStr, Long payloadContentSize) {
+//        storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, null, payloadContentStr, payloadContentSize);
+//    }
+
+    public void storeTextInS3(String s3BucketName, String s3Key, String payloadContentStr, Long payloadContentSize) {
         InputStream payloadContentStream = new ByteArrayInputStream(payloadContentStr.getBytes(StandardCharsets.UTF_8));
         ObjectMetadata payloadContentStreamMetadata = new ObjectMetadata();
         payloadContentStreamMetadata.setContentLength(payloadContentSize);
@@ -91,15 +136,6 @@ public class S3Dao {
             LOG.error(errorMessage, e);
             throw new AmazonClientException(errorMessage, e);
         }
-    }
-
-    public void storeTextInS3(String s3BucketName, String s3Key, SSEAwsKeyManagementParams sseAwsKeyManagementParams,
-                              String payloadContentStr, Long payloadContentSize) {
-        storeTextInS3(s3BucketName, s3Key, sseAwsKeyManagementParams, null, payloadContentStr, payloadContentSize);
-    }
-
-    public void storeTextInS3(String s3BucketName, String s3Key, String payloadContentStr, Long payloadContentSize) {
-        storeTextInS3(s3BucketName, s3Key, null, payloadContentStr, payloadContentSize);
     }
 
     public void deletePayloadFromS3(String s3BucketName, String s3Key) {

--- a/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
@@ -17,10 +17,12 @@ public class PayloadStorageConfigurationTest {
     private static String s3BucketName = "test-bucket-name";
     private static String s3ServerSideEncryptionKMSKeyId = "test-customer-managed-kms-key-id";
     private SSEAwsKeyManagementParams sseAwsKeyManagementParams;
+    private CannedAccessControlList cannedAccessControlList;
 
     @Before
     public void setup() {
         sseAwsKeyManagementParams = new SSEAwsKeyManagementParams(s3ServerSideEncryptionKMSKeyId);
+        cannedAccessControlList = CannedAccessControlList.BucketOwnerFullControl;
     }
 
     @Test
@@ -34,7 +36,8 @@ public class PayloadStorageConfigurationTest {
 
         payloadStorageConfiguration.withPayloadSupportEnabled(s3, s3BucketName)
                 .withAlwaysThroughS3(alwaysThroughS3).withPayloadSizeThreshold(payloadSizeThreshold)
-                .withSSEAwsKeyManagementParams(sseAwsKeyManagementParams);
+                .withSSEAwsKeyManagementParams(sseAwsKeyManagementParams)
+                .withCannedAccessControlList(cannedAccessControlList);
 
         PayloadStorageConfiguration newPayloadStorageConfiguration = new PayloadStorageConfiguration(payloadStorageConfiguration);
 
@@ -42,6 +45,7 @@ public class PayloadStorageConfigurationTest {
         assertEquals(s3BucketName, newPayloadStorageConfiguration.getS3BucketName());
         assertEquals(sseAwsKeyManagementParams, newPayloadStorageConfiguration.getSSEAwsKeyManagementParams());
         assertEquals(s3ServerSideEncryptionKMSKeyId, newPayloadStorageConfiguration.getSSEAwsKeyManagementParams().getAwsKmsKeyId());
+        assertEquals(cannedAccessControlList, newPayloadStorageConfiguration.getCannedAccessControlList());
         assertTrue(newPayloadStorageConfiguration.isPayloadSupportEnabled());
         assertEquals(alwaysThroughS3, newPayloadStorageConfiguration.isAlwaysThroughS3());
         assertEquals(payloadSizeThreshold, newPayloadStorageConfiguration.getPayloadSizeThreshold());
@@ -97,9 +101,8 @@ public class PayloadStorageConfigurationTest {
 
         assertFalse(payloadStorageConfiguration.isCannedAccessControlListDefined());
 
-        final CannedAccessControlList accessControlList = CannedAccessControlList.BucketOwnerFullControl;
-        payloadStorageConfiguration.withCannedAccessControlList(accessControlList);
+        payloadStorageConfiguration.withCannedAccessControlList(cannedAccessControlList);
         assertTrue(payloadStorageConfiguration.isCannedAccessControlListDefined());
-        assertEquals(accessControlList, payloadStorageConfiguration.getCannedAccessControlList());
+        assertEquals(cannedAccessControlList, payloadStorageConfiguration.getCannedAccessControlList());
     }
 }

--- a/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
@@ -1,6 +1,7 @@
 package software.amazon.payloadoffloading;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,5 +88,18 @@ public class PayloadStorageConfigurationTest {
         payloadStorageConfiguration.setSSEAwsKeyManagementParams(sseAwsKeyManagementParams);
         assertEquals(s3ServerSideEncryptionKMSKeyId, payloadStorageConfiguration.getSSEAwsKeyManagementParams()
             .getAwsKmsKeyId());
+    }
+
+    @Test
+    public void testCannedAccessControlList() {
+
+        PayloadStorageConfiguration payloadStorageConfiguration = new PayloadStorageConfiguration();
+
+        assertFalse(payloadStorageConfiguration.isCannedAccessControlListDefined());
+
+        final CannedAccessControlList accessControlList = CannedAccessControlList.BucketOwnerFullControl;
+        payloadStorageConfiguration.withCannedAccessControlList(accessControlList);
+        assertTrue(payloadStorageConfiguration.isCannedAccessControlListDefined());
+        assertEquals(accessControlList, payloadStorageConfiguration.getCannedAccessControlList());
     }
 }

--- a/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
@@ -1,6 +1,7 @@
 package software.amazon.payloadoffloading;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -75,9 +76,10 @@ public class S3BackedPayloadStoreTest {
 
         ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<SSEAwsKeyManagementParams> sseArgsCaptor = ArgumentCaptor.forClass(SSEAwsKeyManagementParams.class);
+        ArgumentCaptor<CannedAccessControlList> cannedArgsCaptor = ArgumentCaptor.forClass(CannedAccessControlList.class);
 
         verify(mockS3Dao, times(1)).storeTextInS3(eq(S3_BUCKET_NAME), keyCaptor.capture(),
-                sseArgsCaptor.capture(), eq(ANY_PAYLOAD), eq(ANY_PAYLOAD_LENGTH));
+                sseArgsCaptor.capture(), cannedArgsCaptor.capture(), eq(ANY_PAYLOAD), eq(ANY_PAYLOAD_LENGTH));
 
         PayloadS3Pointer expectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, keyCaptor.getValue());
         assertEquals(expectedPayloadPointer.toJson(), actualPayloadPointer);
@@ -107,8 +109,11 @@ public class S3BackedPayloadStoreTest {
         ArgumentCaptor<SSEAwsKeyManagementParams> sseArgsCaptor = ArgumentCaptor
                 .forClass(SSEAwsKeyManagementParams.class);
 
+        ArgumentCaptor<CannedAccessControlList> cannedArgsCaptor = ArgumentCaptor
+                .forClass(CannedAccessControlList.class);
+
         verify(mockS3Dao, times(2)).storeTextInS3(eq(S3_BUCKET_NAME), anyOtherKeyCaptor.capture(),
-                sseArgsCaptor.capture(), eq(ANY_PAYLOAD), eq(ANY_PAYLOAD_LENGTH));
+                sseArgsCaptor.capture(), cannedArgsCaptor.capture(), eq(ANY_PAYLOAD), eq(ANY_PAYLOAD_LENGTH));
 
         String anyS3Key = anyOtherKeyCaptor.getAllValues().get(0);
         String anyOtherS3Key = anyOtherKeyCaptor.getAllValues().get(1);
@@ -141,6 +146,7 @@ public class S3BackedPayloadStoreTest {
                         any(String.class),
                         any(String.class),
                         expectedParams == null ? isNull() : any(SSEAwsKeyManagementParams.class),
+                        any(),
                         any(String.class),
                         any(Long.class));
 

--- a/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,38 +33,6 @@ public class S3BackedPayloadStoreTest {
     public void setup() {
         s3Dao = mock(S3Dao.class);
         payloadStore = new S3BackedPayloadStore(s3Dao, S3_BUCKET_NAME);
-    }
-
-    private Object[] testData() {
-        // Here, we create separate mock of S3Dao because JUnitParamsRunner collects parameters
-        // for tests well before invocation of @Before or @BeforeClass methods.
-        // That means our default s3Dao mock isn't instantiated until then. For parameterized tests,
-        // we instantiate our local S3Dao mock per combination, pass it to S3BackedPayloadStore and also pass it
-        // as test parameter to allow verifying calls to the mockS3Dao.
-        S3Dao noEncryptionS3Dao = mock(S3Dao.class);
-        S3Dao defaultEncryptionS3Dao = mock(S3Dao.class);
-        S3Dao customerKMSKeyEncryptionS3Dao = mock(S3Dao.class);
-        return new Object[][]{
-                // No S3 SSE-KMS encryption
-                {
-                    new S3BackedPayloadStore(noEncryptionS3Dao, S3_BUCKET_NAME),
-                    null,
-                    noEncryptionS3Dao
-                },
-                // S3 SSE-KMS encryption with AWS managed KMS keys
-//                {
-//                    new S3BackedPayloadStore(defaultEncryptionS3Dao, S3_BUCKET_NAME, new SSEAwsKeyManagementParams()),
-//                    new SSEAwsKeyManagementParams(),
-//                    defaultEncryptionS3Dao
-//                },
-//                // S3 SSE-KMS encryption with customer managed KMS key
-//                {
-//                    new S3BackedPayloadStore(customerKMSKeyEncryptionS3Dao, S3_BUCKET_NAME,
-//                        new SSEAwsKeyManagementParams(S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID)),
-//                    new SSEAwsKeyManagementParams(S3_SERVER_SIDE_ENCRYPTION_KMS_KEY_ID),
-//                    customerKMSKeyEncryptionS3Dao
-//                }
-        };
     }
 
     @Test
@@ -112,11 +79,9 @@ public class S3BackedPayloadStoreTest {
     }
 
     @Test
-    @Parameters(method = "testData")
-    public void testStoreOriginalPayloadOnS3Failure(PayloadStore payloadStore,
-                                                    SSEAwsKeyManagementParams expectedParams, S3Dao mockS3Dao) {
+    public void testStoreOriginalPayloadOnS3Failure() {
         doThrow(new AmazonClientException("S3 Exception"))
-                .when(mockS3Dao)
+                .when(s3Dao)
                 .storeTextInS3(
                         any(String.class),
                         any(String.class),

--- a/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
@@ -1,0 +1,78 @@
+package software.amazon.payloadoffloading;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(JUnitParamsRunner.class)
+public class S3DaoTest {
+
+    private static String s3ServerSideEncryptionKMSKeyId = "test-customer-managed-kms-key-id";
+    private static final String S3_BUCKET_NAME = "test-bucket-name";
+    private static final String ANY_PAYLOAD = "AnyPayload";
+    private static final String ANY_S3_KEY = "AnyS3key";
+    private static final Long ANY_PAYLOAD_LENGTH = 300000L;
+    private SSEAwsKeyManagementParams sseAwsKeyManagementParams;
+    private CannedAccessControlList cannedAccessControlList;
+    private AmazonS3 s3Client;
+    private S3Dao dao;
+
+    @Before
+    public void setup() {
+        s3Client = mock(AmazonS3.class);
+        sseAwsKeyManagementParams = new SSEAwsKeyManagementParams(s3ServerSideEncryptionKMSKeyId);
+        cannedAccessControlList = CannedAccessControlList.BucketOwnerFullControl;
+    }
+
+    @Test
+    public void storeTextInS3WithoutSSEOrCannedTest() {
+        dao = new S3Dao(s3Client);
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD, ANY_PAYLOAD_LENGTH);
+
+        verify(s3Client, times(1)).putObject(argument.capture());
+
+        assertNull(argument.getValue().getSSEAwsKeyManagementParams());
+        assertNull(argument.getValue().getCannedAcl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().getBucketName());
+    }
+
+    @Test
+    public void storeTextInS3WithSSETest() {
+        dao = new S3Dao(s3Client, sseAwsKeyManagementParams, null);
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD, ANY_PAYLOAD_LENGTH);
+
+        verify(s3Client, times(1)).putObject(argument.capture());
+
+        assertEquals(sseAwsKeyManagementParams, argument.getValue().getSSEAwsKeyManagementParams());
+        assertNull(argument.getValue().getCannedAcl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().getBucketName());
+    }
+
+    @Test
+    public void storeTextInS3WithBothTest() {
+        dao = new S3Dao(s3Client, sseAwsKeyManagementParams, cannedAccessControlList);
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD, ANY_PAYLOAD_LENGTH);
+
+        verify(s3Client, times(1)).putObject(argument.capture());
+
+        assertEquals(sseAwsKeyManagementParams, argument.getValue().getSSEAwsKeyManagementParams());
+        assertEquals(cannedAccessControlList, argument.getValue().getCannedAcl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().getBucketName());
+    }
+}

--- a/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
@@ -2,7 +2,6 @@ package software.amazon.payloadoffloading;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import junitparams.JUnitParamsRunner;


### PR DESCRIPTION
Issue #7 

Description of changes:
Add support for Canned access control lists

Canned access control lists are commonly used access control lists (ACL) that can be used as a shortcut when applying an access control list to Amazon S3 buckets and objects. This will also allow SQSExtendedClient to add cross account support.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
