### PR TITLE
feat: Added support for object canned access control lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can download release builds through the [releases section of this](https://g
   <dependency>
     <groupId>software.amazon.payloadoffloading</groupId>
     <artifactId>payloadoffloading-common</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
   </dependency>
 ```   
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can download release builds through the [releases section of this](https://g
   <dependency>
     <groupId>software.amazon.payloadoffloading</groupId>
     <artifactId>payloadoffloading-common</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
   </dependency>
 ```                                                                                                                     
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.payloadoffloading</groupId>
     <artifactId>payloadoffloading-common</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
     <name>Payload offloading common library for AWS</name>
     <description>Common library between extended Amazon AWS clients to save payloads up to 2GB on Amazon S3.</description>

--- a/src/main/java/software/amazon/payloadoffloading/PayloadStorageConfiguration.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStorageConfiguration.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 /**
  * <p>Amazon payload storage configuration options such as Amazon S3 client,
@@ -42,11 +43,16 @@ public class PayloadStorageConfiguration {
      * This field is optional, it is set only when we want to configure S3 Server Side Encryption with KMS.
      */
     private ServerSideEncryptionStrategy serverSideEncryptionStrategy;
+    /**
+     * This field is optional, it is set only when we want to add access control list to Amazon S3 buckets and objects
+     */
+    private ObjectCannedACL objectCannedACL;
 
     public PayloadStorageConfiguration() {
         s3 = null;
         s3BucketName = null;
         serverSideEncryptionStrategy = null;
+        objectCannedACL = null;
     }
 
     public PayloadStorageConfiguration(PayloadStorageConfiguration other) {
@@ -56,6 +62,7 @@ public class PayloadStorageConfiguration {
         this.alwaysThroughS3 = other.isAlwaysThroughS3();
         this.payloadSizeThreshold = other.getPayloadSizeThreshold();
         this.serverSideEncryptionStrategy = other.getServerSideEncryptionStrategy();
+        this.objectCannedACL = other.getObjectCannedACL();
     }
 
     /**
@@ -235,4 +242,38 @@ public class PayloadStorageConfiguration {
         return this.serverSideEncryptionStrategy;
     }
 
+    /**
+     * Configures the ACL to apply to the Amazon S3 putObject request.
+     * @param objectCannedACL
+     *            The ACL to be used when storing objects in Amazon S3
+     */
+    public void setObjectCannedACL(ObjectCannedACL objectCannedACL) {
+        this.objectCannedACL = objectCannedACL;
+    }
+
+    /**
+     * Configures the ACL to apply to the Amazon S3 putObject request.
+     * @param objectCannedACL
+     *            The ACL to be used when storing objects in Amazon S3
+     */
+    public PayloadStorageConfiguration withObjectCannedACL(ObjectCannedACL objectCannedACL) {
+        setObjectCannedACL(objectCannedACL);
+        return this;
+    }
+
+    /**
+     * Checks whether an ACL have been configured for storing objects in Amazon S3.
+     * @return True if ACL is defined
+     */
+    public boolean isObjectCannedACLDefined() {
+        return null != objectCannedACL;
+    }
+
+    /**
+     * Gets the AWS ACL to apply to the Amazon S3 putObject request.
+     * @return Amazon S3 object ACL
+     */
+    public ObjectCannedACL getObjectCannedACL() {
+        return objectCannedACL;
+    }
 }

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -2,6 +2,7 @@ package software.amazon.payloadoffloading;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.util.UUID;
 
@@ -14,15 +15,21 @@ public class S3BackedPayloadStore implements PayloadStore {
     private final String s3BucketName;
     private final S3Dao s3Dao;
     private final ServerSideEncryptionStrategy serverSideEncryptionStrategy;
+    private final ObjectCannedACL objectCannedACL;
 
     public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName) {
         this(s3Dao, s3BucketName, null);
     }
 
     public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName, ServerSideEncryptionStrategy serverSideEncryptionStrategy) {
+        this(s3Dao, s3BucketName, serverSideEncryptionStrategy, null);
+    }
+
+    public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName, ServerSideEncryptionStrategy serverSideEncryptionStrategy, ObjectCannedACL objectCannedACL) {
         this.s3BucketName = s3BucketName;
         this.s3Dao = s3Dao;
         this.serverSideEncryptionStrategy = serverSideEncryptionStrategy;
+        this.objectCannedACL = objectCannedACL;
     }
 
     @Override
@@ -30,7 +37,7 @@ public class S3BackedPayloadStore implements PayloadStore {
         String s3Key = UUID.randomUUID().toString();
 
         // Store the payload content in S3.
-        s3Dao.storeTextInS3(s3BucketName, s3Key, serverSideEncryptionStrategy, payload);
+        s3Dao.storeTextInS3(s3BucketName, s3Key, serverSideEncryptionStrategy, objectCannedACL, payload);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
 
         // Convert S3 pointer (bucket name, key, etc) to JSON string

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -2,7 +2,6 @@ package software.amazon.payloadoffloading;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.util.UUID;
 
@@ -14,30 +13,17 @@ public class S3BackedPayloadStore implements PayloadStore {
 
     private final String s3BucketName;
     private final S3Dao s3Dao;
-    private final ServerSideEncryptionStrategy serverSideEncryptionStrategy;
-    private final ObjectCannedACL objectCannedACL;
 
     public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName) {
-        this(s3Dao, s3BucketName, null);
-    }
-
-    public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName, ServerSideEncryptionStrategy serverSideEncryptionStrategy) {
-        this(s3Dao, s3BucketName, serverSideEncryptionStrategy, null);
-    }
-
-    public S3BackedPayloadStore(S3Dao s3Dao, String s3BucketName, ServerSideEncryptionStrategy serverSideEncryptionStrategy, ObjectCannedACL objectCannedACL) {
         this.s3BucketName = s3BucketName;
         this.s3Dao = s3Dao;
-        this.serverSideEncryptionStrategy = serverSideEncryptionStrategy;
-        this.objectCannedACL = objectCannedACL;
     }
 
     @Override
     public String storeOriginalPayload(String payload) {
         String s3Key = UUID.randomUUID().toString();
 
-        // Store the payload content in S3.
-        s3Dao.storeTextInS3(s3BucketName, s3Key, serverSideEncryptionStrategy, objectCannedACL, payload);
+        s3Dao.storeTextInS3(s3BucketName, s3Key, payload);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
 
         // Convert S3 pointer (bucket name, key, etc) to JSON string

--- a/src/main/java/software/amazon/payloadoffloading/S3Dao.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3Dao.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.utils.IoUtils;
 
@@ -56,10 +57,15 @@ public class S3Dao {
         return embeddedText;
     }
 
-    public void storeTextInS3(String s3BucketName, String s3Key, ServerSideEncryptionStrategy serverSideEncryptionStrategy, String payloadContentStr) {
+    public void storeTextInS3(String s3BucketName, String s3Key, ServerSideEncryptionStrategy serverSideEncryptionStrategy,
+                              ObjectCannedACL objectCannedACL, String payloadContentStr) {
         PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
                 .bucket(s3BucketName)
                 .key(s3Key);
+
+        if (objectCannedACL != null) {
+            putObjectRequestBuilder.acl(objectCannedACL);
+        }
 
         // https://docs.aws.amazon.com/AmazonS3/latest/dev/kms-using-sdks.html
         if (serverSideEncryptionStrategy != null) {

--- a/src/main/java/software/amazon/payloadoffloading/S3Dao.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3Dao.java
@@ -22,9 +22,17 @@ import java.io.IOException;
 public class S3Dao {
     private static final Logger LOG = LoggerFactory.getLogger(S3Dao.class);
     private final S3Client s3Client;
+    private final ServerSideEncryptionStrategy serverSideEncryptionStrategy;
+    private final ObjectCannedACL objectCannedACL;
 
     public S3Dao(S3Client s3Client) {
+        this(s3Client, null, null);
+    }
+
+    public S3Dao(S3Client s3Client, ServerSideEncryptionStrategy serverSideEncryptionStrategy, ObjectCannedACL objectCannedACL) {
         this.s3Client = s3Client;
+        this.serverSideEncryptionStrategy = serverSideEncryptionStrategy;
+        this.objectCannedACL = objectCannedACL;
     }
 
     public String getTextFromS3(String s3BucketName, String s3Key) {
@@ -57,8 +65,7 @@ public class S3Dao {
         return embeddedText;
     }
 
-    public void storeTextInS3(String s3BucketName, String s3Key, ServerSideEncryptionStrategy serverSideEncryptionStrategy,
-                              ObjectCannedACL objectCannedACL, String payloadContentStr) {
+    public void storeTextInS3(String s3BucketName, String s3Key, String payloadContentStr) {
         PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
                 .bucket(s3BucketName)
                 .key(s3Key);

--- a/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
@@ -1,6 +1,5 @@
 package software.amazon.payloadoffloading;
 
-import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -14,7 +13,6 @@ import static org.junit.Assert.*;
 public class PayloadStorageConfigurationTest {
 
     private static final String s3BucketName = "test-bucket-name";
-    private static final String s3ServerSideEncryptionKMSKeyId = "test-customer-managed-kms-key-id";
     private static final ServerSideEncryptionStrategy SERVER_SIDE_ENCRYPTION_STRATEGY = ServerSideEncryptionFactory.awsManagedCmk();
     private final ObjectCannedACL objectCannelACL = ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL;
 

--- a/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
@@ -1,7 +1,9 @@
 package software.amazon.payloadoffloading;
 
+import org.junit.Before;
 import org.junit.Test;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import static org.mockito.Mockito.mock;
 import static org.junit.Assert.*;
@@ -14,6 +16,7 @@ public class PayloadStorageConfigurationTest {
     private static final String s3BucketName = "test-bucket-name";
     private static final String s3ServerSideEncryptionKMSKeyId = "test-customer-managed-kms-key-id";
     private static final ServerSideEncryptionStrategy SERVER_SIDE_ENCRYPTION_STRATEGY = ServerSideEncryptionFactory.awsManagedCmk();
+    private final ObjectCannedACL objectCannelACL = ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL;
 
     @Test
     public void testCopyConstructor() {
@@ -27,7 +30,8 @@ public class PayloadStorageConfigurationTest {
         payloadStorageConfiguration.withPayloadSupportEnabled(s3, s3BucketName)
                 .withAlwaysThroughS3(alwaysThroughS3)
                 .withPayloadSizeThreshold(payloadSizeThreshold)
-                .withServerSideEncryption(SERVER_SIDE_ENCRYPTION_STRATEGY);
+                .withServerSideEncryption(SERVER_SIDE_ENCRYPTION_STRATEGY)
+                .withObjectCannedACL(objectCannelACL);
 
         PayloadStorageConfiguration newPayloadStorageConfiguration = new PayloadStorageConfiguration(payloadStorageConfiguration);
 
@@ -35,6 +39,7 @@ public class PayloadStorageConfigurationTest {
         assertEquals(s3BucketName, newPayloadStorageConfiguration.getS3BucketName());
         assertEquals(SERVER_SIDE_ENCRYPTION_STRATEGY, newPayloadStorageConfiguration.getServerSideEncryptionStrategy());
         assertTrue(newPayloadStorageConfiguration.isPayloadSupportEnabled());
+        assertEquals(objectCannelACL, newPayloadStorageConfiguration.getObjectCannedACL());
         assertEquals(alwaysThroughS3, newPayloadStorageConfiguration.isAlwaysThroughS3());
         assertEquals(payloadSizeThreshold, newPayloadStorageConfiguration.getPayloadSizeThreshold());
         assertNotSame(newPayloadStorageConfiguration, payloadStorageConfiguration);
@@ -79,5 +84,16 @@ public class PayloadStorageConfigurationTest {
 
         payloadStorageConfiguration.setServerSideEncryptionStrategy(SERVER_SIDE_ENCRYPTION_STRATEGY);
         assertEquals(SERVER_SIDE_ENCRYPTION_STRATEGY, payloadStorageConfiguration.getServerSideEncryptionStrategy());
+    }
+
+    @Test
+    public void testCannedAccessControlList() {
+        PayloadStorageConfiguration payloadStorageConfiguration = new PayloadStorageConfiguration();
+
+        assertFalse(payloadStorageConfiguration.isObjectCannedACLDefined());
+
+        payloadStorageConfiguration.withObjectCannedACL(objectCannelACL);
+        assertTrue(payloadStorageConfiguration.isObjectCannedACLDefined());
+        assertEquals(objectCannelACL, payloadStorageConfiguration.getObjectCannedACL());
     }
 }

--- a/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.util.Objects;
 
@@ -78,9 +79,10 @@ public class S3BackedPayloadStoreTest {
 
         ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<ServerSideEncryptionStrategy> sseArgsCaptor = ArgumentCaptor.forClass(ServerSideEncryptionStrategy.class);
+        ArgumentCaptor<ObjectCannedACL> cannedArgsCaptor = ArgumentCaptor.forClass(ObjectCannedACL.class);
 
         verify(mockS3Dao, times(1)).storeTextInS3(eq(S3_BUCKET_NAME), keyCaptor.capture(),
-                sseArgsCaptor.capture(), eq(ANY_PAYLOAD));
+                sseArgsCaptor.capture(), cannedArgsCaptor.capture(), eq(ANY_PAYLOAD));
 
         PayloadS3Pointer expectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, keyCaptor.getValue());
         assertEquals(expectedPayloadPointer.toJson(), actualPayloadPointer);
@@ -105,9 +107,10 @@ public class S3BackedPayloadStoreTest {
 
         ArgumentCaptor<String> anyOtherKeyCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<ServerSideEncryptionStrategy> sseArgsCaptor = ArgumentCaptor.forClass(ServerSideEncryptionStrategy.class);
+        ArgumentCaptor<ObjectCannedACL> cannedArgsCaptor = ArgumentCaptor.forClass(ObjectCannedACL.class);
 
         verify(mockS3Dao, times(2)).storeTextInS3(eq(S3_BUCKET_NAME), anyOtherKeyCaptor.capture(),
-                sseArgsCaptor.capture(), eq(ANY_PAYLOAD));
+                sseArgsCaptor.capture(), cannedArgsCaptor.capture(), eq(ANY_PAYLOAD));
 
         String anyS3Key = anyOtherKeyCaptor.getAllValues().get(0);
         String anyOtherS3Key = anyOtherKeyCaptor.getAllValues().get(1);
@@ -138,6 +141,7 @@ public class S3BackedPayloadStoreTest {
                         any(String.class),
                         any(String.class),
                         // Can be String or null
+                        any(),
                         any(),
                         any(String.class));
 

--- a/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
@@ -1,0 +1,75 @@
+package software.amazon.payloadoffloading;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(JUnitParamsRunner.class)
+public class S3DaoTest {
+
+    private static String s3ServerSideEncryptionKMSKeyId = "test-customer-managed-kms-key-id";
+    private static final String S3_BUCKET_NAME = "test-bucket-name";
+    private static final String ANY_PAYLOAD = "AnyPayload";
+    private static final String ANY_S3_KEY = "AnyS3key";
+    private ServerSideEncryptionStrategy serverSideEncryptionStrategy = ServerSideEncryptionFactory.awsManagedCmk();
+    private ObjectCannedACL objectCannedACL = ObjectCannedACL.PUBLIC_READ;
+    private S3Client s3Client;
+    private S3Dao dao;
+
+    @Before
+    public void setup() {
+        s3Client = mock(S3Client.class);
+    }
+
+    @Test
+    public void storeTextInS3WithoutSSEOrCannedTest() {
+        dao = new S3Dao(s3Client);
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD);
+
+        verify(s3Client, times(1)).putObject(argument.capture(), any(RequestBody.class));
+
+        assertNull(argument.getValue().serverSideEncryption());
+        assertNull(argument.getValue().acl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().bucket());
+    }
+
+    @Test
+    public void storeTextInS3WithSSETest() {
+        dao = new S3Dao(s3Client, serverSideEncryptionStrategy, null);
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD);
+
+        verify(s3Client, times(1)).putObject(argument.capture(), any(RequestBody.class));
+
+        assertEquals(ServerSideEncryption.AWS_KMS, argument.getValue().serverSideEncryption());
+        assertNull(argument.getValue().acl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().bucket());
+    }
+
+    @Test
+    public void storeTextInS3WithBothTest() {
+        dao = new S3Dao(s3Client, serverSideEncryptionStrategy, objectCannedACL);
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD);
+
+        verify(s3Client, times(1)).putObject(argument.capture(), any(RequestBody.class));
+
+        assertEquals(ServerSideEncryption.AWS_KMS, argument.getValue().serverSideEncryption());
+        assertEquals(objectCannedACL, argument.getValue().acl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().bucket());
+    }
+}

--- a/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3DaoTest.java
@@ -11,8 +11,12 @@ import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(JUnitParamsRunner.class)
 public class S3DaoTest {


### PR DESCRIPTION
Issue #7

Description of changes:
Add support for Canned access control lists

Canned access control lists are commonly used access control lists (ACL) that can be used as a shortcut when applying an access control list to Amazon S3 buckets and objects. This will also allow SQSExtendedClient to add cross account support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.