### PR TITLE
Add configurable s3Key as an optional parameter

### DIFF
--- a/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
@@ -11,7 +11,6 @@ public interface PayloadStore {
      * Stores payload in a store that has higher payload size limit than that is supported by original payload store.
      *
      * @param payload
-     * @param optional  an array of optional parameters. optional[0] should be a custom s3Key.
      * @return a pointer that must be used to retrieve the original payload later.
      * @throws SdkClientException  If any internal errors are encountered on the client side while
      *                                attempting to make the request or handle the response. For example
@@ -19,7 +18,21 @@ public interface PayloadStore {
      * @throws S3Exception If an error response is returned by actual PayloadStore indicating
      *                                either a problem with the data in the request, or a server side issue.
      */
-    String storeOriginalPayload(String payload, String... optional);
+    String storeOriginalPayload(String payload);
+
+    /**
+     * Stores payload in a store that has higher payload size limit than that is supported by original payload store.
+     *
+     * @param payload
+     * @param s3Key
+     * @return a pointer that must be used to retrieve the original payload later.
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response. For example
+     *                                if a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                either a problem with the data in the request, or a server side issue.
+     */
+    String storeOriginalPayload(String payload, String s3Key);
 
     /**
      * Retrieves the original payload using the given payloadPointer. The pointer must

--- a/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
@@ -11,6 +11,7 @@ public interface PayloadStore {
      * Stores payload in a store that has higher payload size limit than that is supported by original payload store.
      *
      * @param payload
+     * @param optional  an array of optional parameters. optional[0] should be a custom s3Key.
      * @return a pointer that must be used to retrieve the original payload later.
      * @throws SdkClientException  If any internal errors are encountered on the client side while
      *                                attempting to make the request or handle the response. For example
@@ -18,7 +19,7 @@ public interface PayloadStore {
      * @throws S3Exception If an error response is returned by actual PayloadStore indicating
      *                                either a problem with the data in the request, or a server side issue.
      */
-    String storeOriginalPayload(String payload);
+    String storeOriginalPayload(String payload, String... optional);
 
     /**
      * Retrieves the original payload using the given payloadPointer. The pointer must

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -20,9 +20,13 @@ public class S3BackedPayloadStore implements PayloadStore {
     }
 
     @Override
-    public String storeOriginalPayload(String payload, String... optional) {
-        String s3Key = optional.length > 0 ? optional[0] : UUID.randomUUID().toString();
+    public String storeOriginalPayload(String payload) {
+        String s3Key = UUID.randomUUID().toString();
+        return storeOriginalPayload(payload, s3Key);
+    }
 
+    @Override
+    public String storeOriginalPayload(String payload, String s3Key) {
         s3Dao.storeTextInS3(s3BucketName, s3Key, payload);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
 

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -20,8 +20,8 @@ public class S3BackedPayloadStore implements PayloadStore {
     }
 
     @Override
-    public String storeOriginalPayload(String payload) {
-        String s3Key = UUID.randomUUID().toString();
+    public String storeOriginalPayload(String payload, String... optional) {
+        String s3Key = optional.length > 0 ? optional[0] : UUID.randomUUID().toString();
 
         s3Dao.storeTextInS3(s3BucketName, s3Key, payload);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");

--- a/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
@@ -50,6 +50,17 @@ public class S3BackedPayloadStoreTest {
     }
 
     @Test
+    public void testStoreOriginalPayloadWithS3KeyOnSuccess() {
+        String actualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD, ANY_S3_KEY);
+
+        verify(s3Dao, times(1)).storeTextInS3(eq(S3_BUCKET_NAME), eq(ANY_S3_KEY),
+                eq(ANY_PAYLOAD));
+
+        PayloadS3Pointer expectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, ANY_S3_KEY);
+        assertEquals(expectedPayloadPointer.toJson(), actualPayloadPointer);
+    }
+
+    @Test
     public void testStoreOriginalPayloadDoesAlwaysCreateNewObjects() {
         //Store any payload
         String anyActualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD);


### PR DESCRIPTION
Contributes to issue #11

*Description of changes:*
In this pull request, I  added an optional parameter to the `PayloadStore.storeOriginalPayload()` function, that is to allow consumers to pass custom value for the `s3Key`.

While Java does not support optional parameters, some workarounds are suggested by the community [here](https://stackoverflow.com/questions/965690/java-optional-parameters), from which I have chosen to use *Varargs* to maintain backward compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.