### PR TITLE
Adding new constructor to S3BackedPayloadStore.

### DIFF
--- a/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
@@ -21,6 +21,20 @@ public interface PayloadStore {
     String storeOriginalPayload(String payload);
 
     /**
+     * Stores payload in a store that has higher payload size limit than that is supported by original payload store.
+     *
+     * @param payload
+     * @param key
+     * @return a pointer that must be used to retrieve the original payload later.
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response. For example
+     *                                if a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                either a problem with the data in the request, or a server side issue.
+     */
+    String storeOriginalPayload(String payload, String key);
+
+    /**
      * Retrieves the original payload using the given payloadPointer. The pointer must
      * have been obtained using {@link storeOriginalPayload}
      *

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStore.java
@@ -21,14 +21,17 @@ public class S3BackedPayloadStore implements PayloadStore {
 
     @Override
     public String storeOriginalPayload(String payload) {
-        String s3Key = UUID.randomUUID().toString();
+        return storeOriginalPayload(payload, null);
+    }
 
+    @Override
+    public String storeOriginalPayload(String payload, String key) {
+        String s3Key = (key == null) ? UUID.randomUUID().toString() : key;
         s3Dao.storeTextInS3(s3BucketName, s3Key, payload);
         LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
 
         // Convert S3 pointer (bucket name, key, etc) to JSON string
         PayloadS3Pointer s3Pointer = new PayloadS3Pointer(s3BucketName, s3Key);
-
         return s3Pointer.toJson();
     }
 

--- a/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreTest.java
@@ -50,6 +50,22 @@ public class S3BackedPayloadStoreTest {
     }
 
     @Test
+    public void testStoreOriginalPayloadOnSuccessWithS3Key() {
+        payloadStore = new S3BackedPayloadStore(s3Dao, S3_BUCKET_NAME);
+        String actualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD, ANY_S3_KEY);
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ServerSideEncryptionStrategy> sseArgsCaptor = ArgumentCaptor.forClass(ServerSideEncryptionStrategy.class);
+        ArgumentCaptor<ObjectCannedACL> cannedArgsCaptor = ArgumentCaptor.forClass(ObjectCannedACL.class);
+
+        verify(s3Dao, times(1)).storeTextInS3(eq(S3_BUCKET_NAME), keyCaptor.capture(),
+                eq(ANY_PAYLOAD));
+
+        PayloadS3Pointer expectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, keyCaptor.getValue());
+        assertEquals(expectedPayloadPointer.toJson(), actualPayloadPointer);
+    }
+
+    @Test
     public void testStoreOriginalPayloadDoesAlwaysCreateNewObjects() {
         //Store any payload
         String anyActualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD);


### PR DESCRIPTION


*Issue #, if available:*
customers not able to define their own s3key while storing the data in s3 bucket.

*Description of changes:*
This new constructor with s3 key will enable the customers to define their own s3 key instead of using UUID which they do not have control, if they want to retrieve later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
