### PR TITLE
Bump aws sdk version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 .idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </developers>
 
     <properties>
-        <aws-java-sdk.version>2.13.64</aws-java-sdk.version>
+        <aws-java-sdk.version>2.16.73</aws-java-sdk.version>
     </properties>
 
     <dependencies>
@@ -121,6 +121,7 @@
                             TODO-RS: Java 8 is more strict about some javadoc tags.
                             We'll need to update quite a few to remove this workaround.
                             -->
+                            <source>8</source>
                             <additionalparam>-Xdoclint:none</additionalparam>
                         </configuration>
                     </execution>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Bumped software.amazon.awssdk version from 2.13.64 to 2.16.73
Added *.iml files to .gitignore
Configured as source for javadoc generation java 8 (at least until the todo is fixed)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
