### PR TITLE
Add S3AsyncClient support.

### DIFF
--- a/src/main/java/software/amazon/payloadoffloading/PayloadStoreAsync.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStoreAsync.java
@@ -1,0 +1,78 @@
+package software.amazon.payloadoffloading;
+
+import java.util.concurrent.CompletableFuture;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * An AWS storage service that supports saving high payload sizes.
+ */
+public interface PayloadStoreAsync {
+
+    /**
+     * Stores payload in a store that has higher payload size limit than that is supported by original payload store.
+     * <p>
+     * This call is asynchronous, and so documented return values and exceptions are propagated through
+     * the returned {@link CompletableFuture}.
+     *
+     * @param payload
+     * @return future value of a pointer that must be used to retrieve the original payload later.
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response. For example
+     *                                if a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                either a problem with the data in the request, or a server side issue.
+     */
+    CompletableFuture<String> storeOriginalPayload(String payload);
+
+    /**
+     * Stores payload in a store that has higher payload size limit than that is supported by original payload store.
+     * <p>
+     * This call is asynchronous, and so documented return values and exceptions are propagated through
+     * the returned {@link CompletableFuture}.
+     *
+     * @param payload
+     * @param s3Key
+     * @return future value of a pointer that must be used to retrieve the original payload later.
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response. For example
+     *                                if a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                either a problem with the data in the request, or a server side issue.
+     */
+    CompletableFuture<String> storeOriginalPayload(String payload, String s3Key);
+
+    /**
+     * Retrieves the original payload using the given payloadPointer. The pointer must
+     * have been obtained using {@link #storeOriginalPayload(String)}
+     * <p>
+     * This call is asynchronous, and so documented return values and exceptions are propagated through
+     * the returned {@link CompletableFuture}.
+     *
+     * @param payloadPointer
+     * @return future value of the original payload
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response. For example
+     *                                if payloadPointer is invalid or a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                a server side issue.
+     */
+    CompletableFuture<String> getOriginalPayload(String payloadPointer);
+
+    /**
+     * Deletes the original payload using the given payloadPointer. The pointer must
+     * have been obtained using {@link #storeOriginalPayload(String)}
+     * <p>
+     * This call is asynchronous, and so documented return values and exceptions are propagated through
+     * the returned {@link CompletableFuture}.
+     *
+     * @param payloadPointer
+     * @return future value that completes when the delete operation finishes
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response to/from PayloadStore.
+     *                                For example, if payloadPointer is invalid or a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                a server side issue.
+     */
+    CompletableFuture<Void> deleteOriginalPayload(String payloadPointer);
+}

--- a/src/main/java/software/amazon/payloadoffloading/S3AsyncDao.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3AsyncDao.java
@@ -1,0 +1,118 @@
+package software.amazon.payloadoffloading;
+
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Dao layer to access S3.
+ */
+public class S3AsyncDao {
+    private static final Logger LOG = LoggerFactory.getLogger(S3AsyncDao.class);
+    private final S3AsyncClient s3Client;
+    private final ServerSideEncryptionStrategy serverSideEncryptionStrategy;
+    private final ObjectCannedACL objectCannedACL;
+
+    public S3AsyncDao(S3AsyncClient s3Client) {
+        this(s3Client, null, null);
+    }
+
+    public S3AsyncDao(
+        S3AsyncClient s3Client,
+        ServerSideEncryptionStrategy serverSideEncryptionStrategy,
+        ObjectCannedACL objectCannedACL) {
+        this.s3Client = s3Client;
+        this.serverSideEncryptionStrategy = serverSideEncryptionStrategy;
+        this.objectCannedACL = objectCannedACL;
+    }
+
+    public CompletableFuture<String> getTextFromS3(String s3BucketName, String s3Key) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(s3Key)
+                .build();
+
+        return s3Client.getObject(getObjectRequest, AsyncResponseTransformer.toBytes())
+            .thenApply(ResponseBytes::asUtf8String)
+            .handle((v, tIn) -> {
+                if (tIn != null) {
+                    Throwable t = Util.unwrapFutureException(tIn);
+                    if (t instanceof SdkException) {
+                        String errorMessage = "Failed to get the S3 object which contains the payload.";
+                        LOG.error(errorMessage, t);
+                        throw SdkException.create(errorMessage, t);
+                    }
+                    if (t instanceof UncheckedIOException) {
+                        String errorMessage = "Failure when handling the message which was read from S3 object.";
+                        LOG.error(errorMessage, t);
+                        throw SdkClientException.create(errorMessage, t);
+                    }
+                    throw new CompletionException(t);
+                }
+                return v;
+            });
+    }
+
+    public CompletableFuture<Void> storeTextInS3(String s3BucketName, String s3Key, String payloadContentStr) {
+        PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
+            .bucket(s3BucketName)
+            .key(s3Key);
+
+        if (objectCannedACL != null) {
+            putObjectRequestBuilder.acl(objectCannedACL);
+        }
+
+        // https://docs.aws.amazon.com/AmazonS3/latest/dev/kms-using-sdks.html
+        if (serverSideEncryptionStrategy != null) {
+            serverSideEncryptionStrategy.decorate(putObjectRequestBuilder);
+        }
+
+        return s3Client.putObject(putObjectRequestBuilder.build(), AsyncRequestBody.fromString(payloadContentStr))
+            .handle((v, tIn) -> {
+                if (tIn != null) {
+                    Throwable t = Util.unwrapFutureException(tIn);
+                    if (t instanceof SdkException) {
+                        String errorMessage = "Failed to store the message content in an S3 object.";
+                        LOG.error(errorMessage, t);
+                        throw SdkException.create(errorMessage, t);
+                    }
+                    throw new CompletionException(t);
+                }
+                return null;
+            });
+    }
+
+    public CompletableFuture<Void> deletePayloadFromS3(String s3BucketName, String s3Key) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(s3Key)
+                .build();
+        return s3Client.deleteObject(deleteObjectRequest)
+            .handle((v, tIn) -> {
+                if (tIn != null) {
+                    Throwable t = Util.unwrapFutureException(tIn);
+                    if (t instanceof SdkException) {
+                        String errorMessage = "Failed to delete the S3 object which contains the payload";
+                        LOG.error(errorMessage, t);
+                        throw SdkException.create(errorMessage, t);
+                    }
+                    throw new CompletionException(t);
+                }
+
+                LOG.info("S3 object deleted, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
+                return null;
+            });
+    }
+}

--- a/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStoreAsync.java
+++ b/src/main/java/software/amazon/payloadoffloading/S3BackedPayloadStoreAsync.java
@@ -1,0 +1,77 @@
+package software.amazon.payloadoffloading;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.payloadoffloading.PayloadS3Pointer;
+
+/**
+ * S3 based implementation for PayloadStoreAsync.
+ */
+public class S3BackedPayloadStoreAsync implements PayloadStoreAsync {
+    private static final Logger LOG = LoggerFactory.getLogger(S3BackedPayloadStoreAsync.class);
+
+    private final String s3BucketName;
+    private final S3AsyncDao s3Dao;
+
+    public S3BackedPayloadStoreAsync(S3AsyncDao s3Dao, String s3BucketName) {
+        this.s3BucketName = s3BucketName;
+        this.s3Dao = s3Dao;
+    }
+
+    @Override
+    public CompletableFuture<String> storeOriginalPayload(String payload) {
+        String s3Key = UUID.randomUUID().toString();
+        return storeOriginalPayload(payload, s3Key);
+    }
+
+    @Override
+    public CompletableFuture<String> storeOriginalPayload(String payload, String s3Key) {
+        return s3Dao.storeTextInS3(s3BucketName, s3Key, payload)
+            .thenApply(v -> {
+                LOG.info("S3 object created, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
+
+                // Convert S3 pointer (bucket name, key, etc) to JSON string
+                PayloadS3Pointer s3Pointer = new PayloadS3Pointer(s3BucketName, s3Key);
+
+                return s3Pointer.toJson();
+            });
+    }
+
+    @Override
+    public CompletableFuture<String> getOriginalPayload(String payloadPointer) {
+        try {
+            PayloadS3Pointer s3Pointer = PayloadS3Pointer.fromJson(payloadPointer);
+
+            String s3BucketName = s3Pointer.getS3BucketName();
+            String s3Key = s3Pointer.getS3Key();
+
+            return s3Dao.getTextFromS3(s3BucketName, s3Key)
+                .thenApply(originalPayload -> {
+                    LOG.info("S3 object read, Bucket name: " + s3BucketName + ", Object key: " + s3Key + ".");
+                    return originalPayload;
+                });
+        } catch (Exception e) {
+            CompletableFuture<String> futureEx = new CompletableFuture<>();
+            futureEx.completeExceptionally((e instanceof RuntimeException) ? e : new CompletionException(e));
+            return futureEx;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteOriginalPayload(String payloadPointer) {
+        try {
+            PayloadS3Pointer s3Pointer = PayloadS3Pointer.fromJson(payloadPointer);
+
+            String s3BucketName = s3Pointer.getS3BucketName();
+            String s3Key = s3Pointer.getS3Key();
+            return s3Dao.deletePayloadFromS3(s3BucketName, s3Key);
+        } catch (Exception e) {
+            CompletableFuture<Void> futureEx = new CompletableFuture<>();
+            futureEx.completeExceptionally((e instanceof RuntimeException) ? e : new CompletionException(e));
+            return futureEx;
+        }
+    }
+}

--- a/src/main/java/software/amazon/payloadoffloading/Util.java
+++ b/src/main/java/software/amazon/payloadoffloading/Util.java
@@ -1,5 +1,6 @@
 package software.amazon.payloadoffloading;
 
+import java.util.concurrent.CompletionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -34,4 +35,12 @@ public class Util {
     public static String getUserAgentHeader(String clientName) {
         return clientName + "/" + VersionInfo.SDK_VERSION;
     }
+
+    public static Throwable unwrapFutureException(Throwable t) {
+        if ((t instanceof CompletionException) && t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
+    }
+
 }

--- a/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/PayloadStorageConfigurationTest.java
@@ -1,6 +1,7 @@
 package software.amazon.payloadoffloading;
 
 import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
@@ -44,6 +45,33 @@ public class PayloadStorageConfigurationTest {
     }
 
     @Test
+    public void testCopyConstructorForAsync() {
+        S3AsyncClient s3Async = mock(S3AsyncClient.class);
+
+        boolean alwaysThroughS3 = true;
+        int payloadSizeThreshold = 500;
+
+        PayloadStorageConfiguration payloadStorageConfiguration = new PayloadStorageConfiguration();
+
+        payloadStorageConfiguration.withPayloadSupportEnabled(s3Async, s3BucketName)
+            .withAlwaysThroughS3(alwaysThroughS3)
+            .withPayloadSizeThreshold(payloadSizeThreshold)
+            .withServerSideEncryption(SERVER_SIDE_ENCRYPTION_STRATEGY)
+            .withObjectCannedACL(objectCannelACL);
+
+        PayloadStorageConfiguration newPayloadStorageConfiguration = new PayloadStorageConfiguration(payloadStorageConfiguration);
+
+        assertEquals(s3Async, newPayloadStorageConfiguration.getS3AsyncClient());
+        assertEquals(s3BucketName, newPayloadStorageConfiguration.getS3BucketName());
+        assertEquals(SERVER_SIDE_ENCRYPTION_STRATEGY, newPayloadStorageConfiguration.getServerSideEncryptionStrategy());
+        assertTrue(newPayloadStorageConfiguration.isPayloadSupportEnabled());
+        assertEquals(objectCannelACL, newPayloadStorageConfiguration.getObjectCannedACL());
+        assertEquals(alwaysThroughS3, newPayloadStorageConfiguration.isAlwaysThroughS3());
+        assertEquals(payloadSizeThreshold, newPayloadStorageConfiguration.getPayloadSizeThreshold());
+        assertNotSame(newPayloadStorageConfiguration, payloadStorageConfiguration);
+    }
+
+    @Test
     public void testPayloadSupportEnabled() {
         S3Client s3 = mock(S3Client.class);
         PayloadStorageConfiguration payloadStorageConfiguration = new PayloadStorageConfiguration();
@@ -51,6 +79,19 @@ public class PayloadStorageConfigurationTest {
 
         assertTrue(payloadStorageConfiguration.isPayloadSupportEnabled());
         assertNotNull(payloadStorageConfiguration.getS3Client());
+        assertNull(payloadStorageConfiguration.getS3AsyncClient());
+        assertEquals(s3BucketName, payloadStorageConfiguration.getS3BucketName());
+    }
+
+    @Test
+    public void testPayloadSupportEnabledForAsync() {
+        S3AsyncClient s3Async = mock(S3AsyncClient.class);
+        PayloadStorageConfiguration payloadStorageConfiguration = new PayloadStorageConfiguration();
+        payloadStorageConfiguration.setPayloadSupportEnabled(s3Async, s3BucketName);
+
+        assertTrue(payloadStorageConfiguration.isPayloadSupportEnabled());
+        assertNull(payloadStorageConfiguration.getS3Client());
+        assertNotNull(payloadStorageConfiguration.getS3AsyncClient());
         assertEquals(s3BucketName, payloadStorageConfiguration.getS3BucketName());
     }
 
@@ -60,6 +101,7 @@ public class PayloadStorageConfigurationTest {
         payloadStorageConfiguration.setPayloadSupportDisabled();
 
         assertNull(payloadStorageConfiguration.getS3Client());
+        assertNull(payloadStorageConfiguration.getS3AsyncClient());
         assertNull(payloadStorageConfiguration.getS3BucketName());
     }
 

--- a/src/test/java/software/amazon/payloadoffloading/S3AsyncDaoTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3AsyncDaoTest.java
@@ -1,0 +1,117 @@
+package software.amazon.payloadoffloading;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+@RunWith(JUnitParamsRunner.class)
+public class S3AsyncDaoTest {
+
+    private static String s3ServerSideEncryptionKMSKeyId = "test-customer-managed-kms-key-id";
+    private static final String S3_BUCKET_NAME = "test-bucket-name";
+    private static final String ANY_PAYLOAD = "AnyPayload";
+    private static final String ANY_S3_KEY = "AnyS3key";
+    private ServerSideEncryptionStrategy serverSideEncryptionStrategy = ServerSideEncryptionFactory.awsManagedCmk();
+    private ObjectCannedACL objectCannedACL = ObjectCannedACL.PUBLIC_READ;
+    private S3AsyncClient s3AsyncClient;
+    private S3AsyncDao dao;
+
+    @Before
+    public void setup() {
+        s3AsyncClient = mock(S3AsyncClient.class);
+    }
+
+    @Test
+    public void storeTextInS3WithoutSSEOrCannedTest() {
+        dao = new S3AsyncDao(s3AsyncClient);
+        when(s3AsyncClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD).join();
+
+        verify(s3AsyncClient, times(1)).putObject(argument.capture(), any(AsyncRequestBody.class));
+
+        assertNull(argument.getValue().serverSideEncryption());
+        assertNull(argument.getValue().acl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().bucket());
+    }
+
+    @Test
+    public void storeTextInS3WithSSETest() {
+        dao = new S3AsyncDao(s3AsyncClient, serverSideEncryptionStrategy, null);
+        when(s3AsyncClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD).join();
+
+        verify(s3AsyncClient, times(1)).putObject(argument.capture(), any(AsyncRequestBody.class));
+
+        assertEquals(ServerSideEncryption.AWS_KMS, argument.getValue().serverSideEncryption());
+        assertNull(argument.getValue().acl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().bucket());
+    }
+
+    @Test
+    public void storeTextInS3WithBothTest() {
+        dao = new S3AsyncDao(s3AsyncClient, serverSideEncryptionStrategy, objectCannedACL);
+        when(s3AsyncClient.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+        ArgumentCaptor<PutObjectRequest> argument = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        dao.storeTextInS3(S3_BUCKET_NAME, ANY_S3_KEY, ANY_PAYLOAD).join();
+
+        verify(s3AsyncClient, times(1)).putObject(argument.capture(), any(AsyncRequestBody.class));
+
+        assertEquals(ServerSideEncryption.AWS_KMS, argument.getValue().serverSideEncryption());
+        assertEquals(objectCannedACL, argument.getValue().acl());
+        assertEquals(S3_BUCKET_NAME, argument.getValue().bucket());
+    }
+
+    @Test
+    public void getTextTest() {
+        dao = new S3AsyncDao(s3AsyncClient);
+        when(s3AsyncClient.getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class))).thenReturn(
+            CompletableFuture.completedFuture(ResponseBytes.fromByteArray(
+                GetObjectRequest.builder().build(), ANY_PAYLOAD.getBytes(StandardCharsets.UTF_8))));
+
+        String payload = dao.getTextFromS3(S3_BUCKET_NAME, ANY_S3_KEY).join();
+
+        verify(s3AsyncClient, times(1)).getObject(any(GetObjectRequest.class), any(AsyncResponseTransformer.class));
+
+        assertEquals(payload, ANY_PAYLOAD);
+    }
+
+    @Test
+    public void deleteTextTest() {
+        dao = new S3AsyncDao(s3AsyncClient);
+        when(s3AsyncClient.deleteObject(any(DeleteObjectRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+
+        dao.deletePayloadFromS3(S3_BUCKET_NAME, ANY_S3_KEY).join();
+
+        verify(s3AsyncClient, times(1)).deleteObject(any(DeleteObjectRequest.class));
+    }
+}

--- a/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreAsyncTest.java
+++ b/src/test/java/software/amazon/payloadoffloading/S3BackedPayloadStoreAsyncTest.java
@@ -1,0 +1,176 @@
+package software.amazon.payloadoffloading;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import junitparams.JUnitParamsRunner;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+
+@RunWith(JUnitParamsRunner.class)
+public class S3BackedPayloadStoreAsyncTest {
+    private static final String S3_BUCKET_NAME = "test-bucket-name";
+    private static final String ANY_PAYLOAD = "AnyPayload";
+    private static final String ANY_S3_KEY = "AnyS3key";
+    private static final String INCORRECT_POINTER_EXCEPTION_MSG = "Failed to read the S3 object pointer from given string";
+    private PayloadStoreAsync payloadStore;
+    private S3AsyncDao s3AsyncDao;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        s3AsyncDao = mock(S3AsyncDao.class);
+        payloadStore = new S3BackedPayloadStoreAsync(s3AsyncDao, S3_BUCKET_NAME);
+    }
+
+    @Test
+    public void testStoreOriginalPayloadOnSuccess() {
+        when(s3AsyncDao.storeTextInS3(any(String.class), any(String.class), any(String.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+        String actualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD).join();
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ServerSideEncryptionStrategy> sseArgsCaptor = ArgumentCaptor.forClass(ServerSideEncryptionStrategy.class);
+        ArgumentCaptor<ObjectCannedACL> cannedArgsCaptor = ArgumentCaptor.forClass(ObjectCannedACL.class);
+
+        verify(s3AsyncDao, times(1)).storeTextInS3(eq(S3_BUCKET_NAME), keyCaptor.capture(),
+            eq(ANY_PAYLOAD));
+
+        PayloadS3Pointer expectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, keyCaptor.getValue());
+        assertEquals(expectedPayloadPointer.toJson(), actualPayloadPointer);
+    }
+
+    @Test
+    public void testStoreOriginalPayloadWithS3KeyOnSuccess() {
+        when(s3AsyncDao.storeTextInS3(any(String.class), any(String.class), any(String.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+        String actualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD, ANY_S3_KEY).join();
+
+        verify(s3AsyncDao, times(1)).storeTextInS3(eq(S3_BUCKET_NAME), eq(ANY_S3_KEY),
+            eq(ANY_PAYLOAD));
+
+        PayloadS3Pointer expectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, ANY_S3_KEY);
+        assertEquals(expectedPayloadPointer.toJson(), actualPayloadPointer);
+    }
+
+    @Test
+    public void testStoreOriginalPayloadDoesAlwaysCreateNewObjects() {
+        //Store any payload
+        when(s3AsyncDao.storeTextInS3(any(String.class), any(String.class), any(String.class))).thenReturn(
+            CompletableFuture.completedFuture(null));
+        String anyActualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD).join();
+
+        //Store any other payload and validate that the pointers are different
+        String anyOtherActualPayloadPointer = payloadStore.storeOriginalPayload(ANY_PAYLOAD).join();
+
+        ArgumentCaptor<String> anyOtherKeyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ServerSideEncryptionStrategy> sseArgsCaptor = ArgumentCaptor.forClass(ServerSideEncryptionStrategy.class);
+        ArgumentCaptor<ObjectCannedACL> cannedArgsCaptor = ArgumentCaptor.forClass(ObjectCannedACL.class);
+
+        verify(s3AsyncDao, times(2)).storeTextInS3(eq(S3_BUCKET_NAME), anyOtherKeyCaptor.capture(),
+            eq(ANY_PAYLOAD));
+
+        String anyS3Key = anyOtherKeyCaptor.getAllValues().get(0);
+        String anyOtherS3Key = anyOtherKeyCaptor.getAllValues().get(1);
+
+        PayloadS3Pointer anyExpectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, anyS3Key);
+        assertEquals(anyExpectedPayloadPointer.toJson(), anyActualPayloadPointer);
+
+        PayloadS3Pointer anyOtherExpectedPayloadPointer = new PayloadS3Pointer(S3_BUCKET_NAME, anyOtherS3Key);
+        assertEquals(anyOtherExpectedPayloadPointer.toJson(), anyOtherActualPayloadPointer);
+
+        assertThat(anyS3Key, Matchers.not(anyOtherS3Key));
+        assertThat(anyActualPayloadPointer, Matchers.not(anyOtherActualPayloadPointer));
+    }
+
+    @Test
+    public void testStoreOriginalPayloadOnS3Failure() {
+        CompletableFuture<Void> sdkEx = new CompletableFuture<>();
+        sdkEx.completeExceptionally(SdkException.create("S3 Exception", new Throwable()));
+        when(s3AsyncDao.storeTextInS3(any(String.class), any(String.class), any(String.class))).thenReturn(sdkEx);
+
+        exception.expect(CompletionException.class);
+        exception.expectMessage("S3 Exception");
+        //Any S3 Dao exception is thrown back as-is to clients
+        payloadStore.storeOriginalPayload(ANY_PAYLOAD).join();
+    }
+
+    @Test
+    public void testGetOriginalPayloadOnSuccess() {
+        PayloadS3Pointer anyPointer = new PayloadS3Pointer(S3_BUCKET_NAME, ANY_S3_KEY);
+        when(s3AsyncDao.getTextFromS3(any(String.class), any(String.class))).thenReturn(
+            CompletableFuture.completedFuture(ANY_PAYLOAD));
+        String actualPayload = payloadStore.getOriginalPayload(anyPointer.toJson()).join();
+
+        ArgumentCaptor<String> bucketNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(s3AsyncDao, times(1)).getTextFromS3(bucketNameCaptor.capture(), keyCaptor.capture());
+
+        assertEquals(ANY_S3_KEY, keyCaptor.getValue());
+        assertEquals(S3_BUCKET_NAME, bucketNameCaptor.getValue());
+        assertEquals(ANY_PAYLOAD, actualPayload);
+    }
+
+    @Test
+    public void testGetOriginalPayloadIncorrectPointer() {
+        exception.expect(CompletionException.class);
+        exception.expectMessage(INCORRECT_POINTER_EXCEPTION_MSG);
+        //Any S3 Dao exception is thrown back as-is to clients
+        payloadStore.getOriginalPayload("IncorrectPointer").join();
+        verifyNoInteractions(s3AsyncDao);
+    }
+
+    @Test
+    public void testGetOriginalPayloadOnS3Failure() {
+        CompletableFuture<String> sdkEx = new CompletableFuture<>();
+        sdkEx.completeExceptionally(SdkException.create("S3 Exception", new Throwable()));
+        when(s3AsyncDao.getTextFromS3(any(String.class), any(String.class))).thenReturn(sdkEx);
+        exception.expect(CompletionException.class);
+        exception.expectMessage("S3 Exception");
+        //Any S3 Dao exception is thrown back as-is to clients
+        PayloadS3Pointer anyPointer = new PayloadS3Pointer(S3_BUCKET_NAME, ANY_S3_KEY);
+        payloadStore.getOriginalPayload(anyPointer.toJson()).join();
+    }
+
+    @Test
+    public void testDeleteOriginalPayloadOnSuccess() {
+        when(s3AsyncDao.deletePayloadFromS3(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+        PayloadS3Pointer anyPointer = new PayloadS3Pointer(S3_BUCKET_NAME, ANY_S3_KEY);
+        payloadStore.deleteOriginalPayload(anyPointer.toJson()).join();
+
+        ArgumentCaptor<String> bucketNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(s3AsyncDao, times(1)).deletePayloadFromS3(bucketNameCaptor.capture(), keyCaptor.capture());
+
+        assertEquals(ANY_S3_KEY, keyCaptor.getValue());
+        assertEquals(S3_BUCKET_NAME, bucketNameCaptor.getValue());
+    }
+
+    @Test
+    public void testDeleteOriginalPayloadIncorrectPointer() {
+        exception.expect(CompletionException.class);
+        exception.expectMessage(INCORRECT_POINTER_EXCEPTION_MSG);
+        payloadStore.deleteOriginalPayload("IncorrectPointer").join();
+        verifyNoInteractions(s3AsyncDao);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* 17

*Description of changes:*

- Split PayloadOffloadingConfiguration into a common base class and synchronous S3 subclass. 
- Added async S3 subclass, DAO, and S3BackedPayloadStore. 
- Added unit tests for new code.

I have a matching PR that I want to submit to add async support to the extended SQS client library if this one is accepted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
