### PR TITLE
Add delete payload batch feature.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.payloadoffloading</groupId>
     <artifactId>payloadoffloading-common</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
     <name>Payload offloading common library for AWS</name>
     <description>Common library between extended Amazon AWS clients to save payloads up to 2GB on Amazon S3.</description>

--- a/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStore.java
@@ -1,5 +1,6 @@
 package software.amazon.payloadoffloading;
 
+import java.util.Collection;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -60,4 +61,20 @@ public interface PayloadStore {
      *                                a server side issue.
      */
     void deleteOriginalPayload(String payloadPointer);
+
+    /**
+     * Deletes original payloads using the given payloadPointers. The pointers must
+     * have been obtained using {@link storeOriginalPayload}
+     * <p>
+     * This call will be more efficient than deleting payloads one at a time if the payloads
+     * are in the same S3 bucket.
+     *
+     * @param payloadPointers
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response to/from PayloadStore.
+     *                                For example, if payloadPointer is invalid or a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                a server side issue.
+     */
+    void deleteOriginalPayloads(Collection<String> payloadPointers);
 }

--- a/src/main/java/software/amazon/payloadoffloading/PayloadStoreAsync.java
+++ b/src/main/java/software/amazon/payloadoffloading/PayloadStoreAsync.java
@@ -1,5 +1,6 @@
 package software.amazon.payloadoffloading;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -75,4 +76,24 @@ public interface PayloadStoreAsync {
      *                                a server side issue.
      */
     CompletableFuture<Void> deleteOriginalPayload(String payloadPointer);
+
+    /**
+     * Deletes the original payload using the given payloadPointer. The pointer must
+     * have been obtained using {@link #storeOriginalPayload(String)}
+     * <p>
+     * This call will be more efficient than deleting payloads one at a time if the payloads
+     * are in the same S3 bucket.
+     * <p>
+     * This call is asynchronous, and so documented return values and exceptions are propagated through
+     * the returned {@link CompletableFuture}.
+     *
+     * @param payloadPointers
+     * @return future value that completes when the delete operation finishes
+     * @throws SdkClientException  If any internal errors are encountered on the client side while
+     *                                attempting to make the request or handle the response to/from PayloadStore.
+     *                                For example, if payloadPointer is invalid or a network connection is not available.
+     * @throws S3Exception If an error response is returned by actual PayloadStore indicating
+     *                                a server side issue.
+     */
+    CompletableFuture<Void> deleteOriginalPayloads(Collection<String> payloadPointers);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add ability to delete a batch of offloaded payloads. By using S3 DeleteObjects, it can reduce the number of separate calls to S3 to one-per-bucket, which should improve efficiency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
